### PR TITLE
Fix RPC input error handling

### DIFF
--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -16,16 +16,20 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
-
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       # publish tags to talos-vmtoolsd:version and talos-vmtoolsd:latest
       # publish branches to talos-vmtoolsd-unstable:branch
       # based on https://medium.com/cooking-with-azure/4e39700ae14c
       - name: Publish
         run: |
-          echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u "${{ github.actor }}" --password-stdin
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
-            IMGPATH=ghcr.io/mologie/talos-vmtoolsd
+            IMGPATH=ghcr.io/${{ github.repository }}
             VERSION=$(echo $VERSION | sed -e 's/^v//')
             docker build . -t $IMGPATH:$VERSION -t $IMGPATH:latest
             docker push $IMGPATH:$VERSION

--- a/internal/nanotoolbox/service.go
+++ b/internal/nanotoolbox/service.go
@@ -226,11 +226,7 @@ func (s *Service) Dispatch(request []byte) []byte {
 
 	if !ok {
 		l.Debug("unknown command")
-<<<<<<< HEAD
-		return []byte("Unknown Command")
-=======
 		return []byte("ERROR Unknown Command")
->>>>>>> b3ccb78 (Use "ERROR" instead of "ERR" when replying failed commands)
 	}
 
 	var args []byte

--- a/internal/nanotoolbox/service.go
+++ b/internal/nanotoolbox/service.go
@@ -22,9 +22,10 @@ package nanotoolbox
 import (
 	"bytes"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"sync"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -217,13 +218,19 @@ func (s *Service) Dispatch(request []byte) []byte {
 
 	// Trim NULL byte terminator
 	name = bytes.TrimRight(name, "\x00")
-	l := s.Log.WithField("handler_name", name)
+	l := s.Log.WithField("handler_name", string(name))
+
+	l.Debug("incoming RPC request")
 
 	handler, ok := s.commandHandlers[string(name)]
 
 	if !ok {
 		l.Debug("unknown command")
+<<<<<<< HEAD
 		return []byte("Unknown Command")
+=======
+		return []byte("ERROR Unknown Command")
+>>>>>>> b3ccb78 (Use "ERROR" instead of "ERR" when replying failed commands)
 	}
 
 	var args []byte
@@ -236,7 +243,7 @@ func (s *Service) Dispatch(request []byte) []byte {
 		response = append([]byte("OK "), response...)
 	} else {
 		l.WithError(err).Warn("error calling handler")
-		response = append([]byte("ERR "), response...)
+		response = append([]byte("ERROR "), response...)
 	}
 
 	return response


### PR DESCRIPTION
In our environment (vSphere 7.0, ESXi 7.0) we got a lot of errors about `Unable to send a message over the communication channel 0` and vSphere did not process any guest info being submitted. In order to debug this, we improved the logging of the tool, the GitHub workflow to actually build images in our fork and ultimately the way error responses were sent. 

We suspect vSphere/ESXi are sending "unknown" RPC requests, which got responded in an invalid way ("Unknown Command" instead of "ERROR Unknown Command"). We've digged into the way `open-vm-toolsd` handle unknown RPC requests and mimiced these.

The tool now works perfectly on our environment.