### PR TITLE
fix: send os uptime in 100s of seconds

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,12 @@
+# Tips for hacking development
+
+## Query `osUptime` for verification
+
+VMware expects to receive uptime information in 100s of seconds. We want to
+make sure it gets what it wants, and for that we must read the vm metric
+`sys.osUptime.latest` from vSphere. This is how we do that using
+[govc](https://github.com/vmware/govmomi):
+
+```shell
+watch ./govc metric.sample vm-276015 sys.osUptime.latest
+```

--- a/internal/integration/guestinfo.go
+++ b/internal/integration/guestinfo.go
@@ -150,7 +150,7 @@ func (g *GuestInfo) setOSName() {
 // setUptime fetches the uptime from Talos and sets it.
 func (g *GuestInfo) setUptime() {
 	g.setString(guestInfoUptime, func() string {
-		return strconv.Itoa(g.talos.Uptime())
+		return strconv.Itoa(g.talos.Uptime() * 100)
 	})
 }
 
@@ -261,5 +261,5 @@ func (g *GuestInfo) Register() {
 
 	// As stated in guestInfoServer.c, VMX expects uptime information in response
 	// to the capabilities request.
-	g.service.AddCapability(fmt.Sprintf("SetGuestInfo  %d %d", guestInfoUptime, g.talos.Uptime()))
+	g.service.AddCapability(fmt.Sprintf("SetGuestInfo  %d %d", guestInfoUptime, g.talos.Uptime()*100))
 }


### PR DESCRIPTION
Recent major rewrite resulted in guest uptime being reported in seconds, instead of 100s of seconds as vmware expects.

Closes #33.