### PR TITLE
feat: implement the rpc subcommand

### DIFF
--- a/cmd/talos-vmtoolsd/main.go
+++ b/cmd/talos-vmtoolsd/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/siderolabs/talos-vmtoolsd/internal/rpc"
 	"github.com/siderolabs/talos-vmtoolsd/internal/talosconnection"
 	"github.com/siderolabs/talos-vmtoolsd/internal/version"
 )
@@ -33,6 +34,18 @@ var rootCmd = &cobra.Command{
 	Long:               "this is a tool like open-vm-tools, but for Talos Linux",
 	PersistentPreRunE:  setup,
 	PersistentPostRunE: cleanup,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if viper.IsSet(flagRPCCommand) {
+			err := rpc.ExecuteRPC(logger, viper.GetString(flagRPCCommand))
+			if err != nil {
+				os.Exit(1)
+			}
+
+			return nil
+		}
+
+		return cmd.Help()
+	},
 }
 
 var errTalosSetupFailed = errors.New("error setting up Talos connection")
@@ -68,6 +81,11 @@ func setup(cmd *cobra.Command, _ []string) error {
 	}
 
 	logger = slog.New(slog.NewTextHandler(os.Stdout, logOpts)).With("command", cmd.Name())
+
+	return nil
+}
+
+func setupTalosClient() error {
 	ctx = context.Background()
 	ctx, ctxCancel = context.WithCancel(ctx) // nolint:fatcontext
 
@@ -115,10 +133,12 @@ func setup(cmd *cobra.Command, _ []string) error {
 }
 
 func cleanup(_ *cobra.Command, _ []string) error {
-	if err := api.Close(); err != nil {
-		logger.Warn("failed to close API client during process shutdown", "err", err)
+	if api != nil {
+		if err := api.Close(); err != nil {
+			logger.Warn("failed to close API client during process shutdown", "err", err)
 
-		return err
+			return err
+		}
 	}
 
 	return nil
@@ -134,6 +154,7 @@ func init() {
 	pf.String(flagTalosConfig, "", "path to talos config file")
 	pf.String(flagTalosNode, "", "talos node to operate on")
 	pf.String(flagLogLevel, "info", "log level (error, warning, info, debug, trace)")
+	pf.String(flagRPCCommand, "", "RPC command for the hypvervisor")
 
 	if err := viper.BindPFlags(pf); err != nil {
 		panic(err)

--- a/cmd/talos-vmtoolsd/rpc.go
+++ b/cmd/talos-vmtoolsd/rpc.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Clément Nussbaumer, PostFinance
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siderolabs/talos-vmtoolsd/internal/rpc"
+)
+
+const (
+	flagRPCCommand = "cmd"
+)
+
+var rpcCmd = &cobra.Command{
+	Use:   "rpc --cmd [command]",
+	Short: "execute an arbitrary RPC command",
+	Long:  "can be used to query the hypervisor with e.g. 'info-get guestinfo.some-metadata'",
+	Run:   rpcCommand,
+}
+
+var rpcCommandFlag string
+
+func init() {
+	rpcCmd.Flags().StringVar(&rpcCommandFlag, flagRPCCommand, "", "RPC command")
+	rootCmd.AddCommand(rpcCmd)
+}
+
+func rpcCommand(_ *cobra.Command, _ []string) {
+	if err := rpc.ExecuteRPC(logger, rpcCommandFlag); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/talos-vmtoolsd/talosquery.go
+++ b/cmd/talos-vmtoolsd/talosquery.go
@@ -20,7 +20,14 @@ func init() {
 	rootCmd.AddCommand(talosqueryCmd)
 }
 
-func talosquery(_ *cobra.Command, _ []string) {
+func talosquery(cmd *cobra.Command, _ []string) {
+	err := setupTalosClient()
+	if err != nil {
+		logger.Error("error while setting up the Talos API client", "err", err)
+
+		return
+	}
+
 	logger.Info("hostname", "dnsname", api.Hostname())
 	logger.Info("os information", "version", api.OSVersion(), "short", api.OSVersionShort())
 	u := api.Uptime()

--- a/cmd/talos-vmtoolsd/vmtoolsd.go
+++ b/cmd/talos-vmtoolsd/vmtoolsd.go
@@ -43,7 +43,13 @@ func init() {
 	rootCmd.AddCommand(vmtoolsdCmd)
 }
 
-func vmtoolsd(_ *cobra.Command, _ []string) error {
+func vmtoolsd(cmd *cobra.Command, _ []string) error {
+	if err := setupTalosClient(); err != nil {
+		logger.Error("error while setting up the Talos API client")
+
+		return err
+	}
+
 	// Simplify deployment to mixed vSphere and non-vSphere clusters by detecting ESXi and stopping
 	// early for other platforms. Admins can avoid the overhead of this idle process by labeling
 	// all ESXi/vSphere nodes and editing talos-vmtoolsd's DaemonSet to run only on those nodes.

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Clément Nussbaumer, PostFinance
+// SPDX-License-Identifier: Apache-2.0
+
+// Package rpc contains the logic to issue arbitrary command to the hypervisor
+package rpc
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/equinix-ms/go-vmw-guestrpc/pkg/nanotoolbox"
+)
+
+func ExecuteRPC(logger *slog.Logger, command string) error {
+	if command == "" {
+		return fmt.Errorf("RPC command cannot be empty")
+	}
+
+	logger.Debug("executing RPC command", "command", command)
+
+	rpci, err := nanotoolbox.NewRPCI(logger.With("module", "RPCI"))
+	if err != nil {
+		return fmt.Errorf("failed to create RPCI: %w", err)
+	}
+
+	if err = rpci.Start(); err != nil {
+		return fmt.Errorf("failed to start RPCI channel: %w", err)
+	}
+
+	defer func() {
+		if err = rpci.Stop(); err != nil {
+			logger.Warn("failed to close RPCI channel", "err", err)
+		}
+	}()
+
+	result, ok, err := rpci.Request([]byte(command))
+	if err != nil {
+		logger.Warn("error while executing RPCI request", "err", err)
+
+		return err
+	}
+
+	if len(result) > 0 {
+		fmt.Println(string(result))
+	}
+
+	if !ok {
+		logger.Debug("RPC request failed", "response", string(result))
+
+		return fmt.Errorf("RPC request failed: %s", string(result))
+	} else {
+		logger.Debug("RPC request successful", "response", string(result))
+
+		return nil
+	}
+}


### PR DESCRIPTION
bypasses all hypervisor checks (and does not register a talos api
client).
can either be used as talos-vmtools --cmd [command] or
talos-vmtools rpc --cmd [command]
to retain compatibility with the official vmtoolsd

closes #25 